### PR TITLE
Remove redirect because of caching weirdness

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -114,7 +114,7 @@ function requireUrlQueryParam(req, resp, next) {
 //   next();
 // });
 app.get('/', (req, resp) => {
-  resp.redirect(301, 'https://web.dev/measure');
+  resp.send('nothing to see here');
 });
 
 app.use(bodyParser.raw());


### PR DESCRIPTION
I noticed Chrome seemed to cache this redirect and web.dev/measure immediately installs a service worker, so it's easy to end up in an annoying state where localhost:8080 is just bound to web.dev/measure. Clearing the application tab doesn't work because of the cached redirect so you need to clear your Chrome browsing data first, then nuke the sw.